### PR TITLE
#130 注文変更APIを実装

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Repository Instructions
+
+## GitHub Workflow
+
+- When committing work for a GitHub issue, prefix the commit message with the issue number.
+  - Example: `#130 注文変更APIを実装`
+- When creating a pull request for a GitHub issue, prefix the pull request title with the issue number.
+  - Example: `#130 注文変更APIを実装`
+- Include `close #<issue number>` in the pull request body so the issue closes when the pull request is merged.
+  - Example: `close #130`

--- a/gmo_fx/api/__init__.py
+++ b/gmo_fx/api/__init__.py
@@ -1,1 +1,1 @@
-from . import *
+from .change_order import *

--- a/gmo_fx/api/change_order.py
+++ b/gmo_fx/api/change_order.py
@@ -7,7 +7,7 @@ from requests import Response
 
 from gmo_fx.api.api_base import PrivateApiBase
 from gmo_fx.api.response import Response as ResponseBase
-from gmo_fx.common import OrderType, SettleType, Side, Symbol
+from gmo_fx.common import SettleType, Side, Symbol
 
 
 @dataclass
@@ -24,7 +24,11 @@ class Order:
         LIMIT = "LIMIT"
         STOP = "STOP"
 
-    OrderType = OrderType
+    class OrderType(Enum):
+        """取引区分"""
+
+        NORMAL = "NORMAL"
+
     SettleType = SettleType
     Side = Side
     Symbol = Symbol
@@ -101,9 +105,6 @@ class ChangeOrderApi(PrivateApiBase):
     ) -> ChangeOrderResponse:
         if order_id is None and client_order_id is None:
             raise ValueError("order_id or client_order_id must be provided")
-
-        if price is None:
-            raise ValueError("price must be provided")
 
         data: dict = {
             "price": str(price),

--- a/gmo_fx/api/change_order.py
+++ b/gmo_fx/api/change_order.py
@@ -1,0 +1,120 @@
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from enum import Enum
+from typing import Optional
+
+from requests import Response
+
+from gmo_fx.api.api_base import PrivateApiBase
+from gmo_fx.api.response import Response as ResponseBase
+from gmo_fx.common import OrderType, SettleType, Side, Symbol
+
+
+@dataclass
+class Order:
+
+    class Status(Enum):
+        ORDERED = "ORDERED"
+        MODIFYING = "MODIFYING"
+        EXECUTED = "EXECUTED"
+
+    class ExecutionType(Enum):
+        """注文タイプ"""
+
+        LIMIT = "LIMIT"
+        STOP = "STOP"
+
+    OrderType = OrderType
+    SettleType = SettleType
+    Side = Side
+    Symbol = Symbol
+
+    root_order_id: int
+    client_order_id: Optional[str]
+    order_id: int
+    symbol: Symbol
+    side: Side
+    order_type: OrderType
+    execution_type: ExecutionType
+    settle_type: SettleType
+    size: int
+    price: float
+    status: Status
+    expiry: date
+    timestamp: datetime
+
+
+class ChangeOrderResponse(ResponseBase):
+    orders: list[Order]
+
+    def __init__(self, response: dict):
+        super().__init__(response)
+
+        data: list[dict] = response["data"]
+        self.orders = [
+            Order(
+                root_order_id=d["rootOrderId"],
+                client_order_id=d.get("clientOrderId"),
+                order_id=d["orderId"],
+                symbol=Order.Symbol(d["symbol"]),
+                side=Order.Side(d["side"]),
+                order_type=Order.OrderType(d["orderType"]),
+                execution_type=Order.ExecutionType(d["executionType"]),
+                settle_type=Order.SettleType(d["settleType"]),
+                size=int(d["size"]),
+                price=float(d["price"]),
+                status=Order.Status(d["status"]),
+                expiry=datetime.strptime(d["expiry"], "%Y%m%d").date(),
+                timestamp=datetime.strptime(
+                    d["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ"
+                ).replace(tzinfo=timezone.utc),
+            )
+            for d in data
+        ]
+
+
+class ChangeOrderApi(PrivateApiBase):
+    @property
+    def _path(self) -> str:
+        return "changeOrder"
+
+    @property
+    def _method(self) -> PrivateApiBase._HttpMethod:
+        return self._HttpMethod.POST
+
+    @property
+    def _response_parser(self):
+        return ChangeOrderResponse
+
+    def _api_error_message(self, response: Response):
+        return (
+            "注文変更が失敗しました\n"
+            f"status code: {response.status_code}\n"
+            f"response: {response.text}"
+        )
+
+    def __call__(
+        self,
+        price: float,
+        order_id: Optional[int] = None,
+        client_order_id: Optional[str] = None,
+    ) -> ChangeOrderResponse:
+        if order_id is None and client_order_id is None:
+            raise ValueError("order_id or client_order_id must be provided")
+
+        if price is None:
+            raise ValueError("price must be provided")
+
+        data: dict = {
+            "price": str(price),
+        }
+
+        if order_id is not None:
+            data["orderId"] = order_id
+
+        if client_order_id is not None:
+            data["clientOrderId"] = client_order_id
+
+        return super().__call__(
+            data=data,
+        )

--- a/tests/test_change_order.py
+++ b/tests/test_change_order.py
@@ -1,0 +1,214 @@
+import json
+from datetime import datetime, timezone
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gmo_fx import ChangeOrderApi as PackageChangeOrderApi
+from gmo_fx.api.change_order import ChangeOrderApi, ChangeOrderResponse, Order
+from tests.api_test_base import ApiTestBase
+
+
+class TestChangeOrderApi(ApiTestBase):
+
+    def call_api(
+        self,
+        price: Optional[float] = 139.0,
+        order_id: Optional[int] = None,
+        client_order_id: Optional[str] = None,
+    ) -> ChangeOrderResponse:
+        return ChangeOrderApi(
+            api_key="",
+            secret_key="",
+        )(
+            price=price,
+            order_id=order_id,
+            client_order_id=client_order_id,
+        )
+
+    def create_response(
+        self,
+        data: Optional[list[dict]] = None,
+        status_code: int = 200,
+        text: Optional[str] = None,
+    ) -> MagicMock:
+        if data is None:
+            data = [self.create_order_data()]
+
+        return super().create_response(
+            data=data,
+            status_code=status_code,
+            text=text,
+        )
+
+    def create_order_data(
+        self,
+        root_order_id: int = 123456789,
+        client_order_id: Optional[str] = "abc123",
+        order_id: int = 123456789,
+        symbol: str = "USD_JPY",
+        side: str = "BUY",
+        order_type: str = "NORMAL",
+        execution_type: str = "LIMIT",
+        settle_type: str = "OPEN",
+        size: int = 100,
+        price: float = 139.0,
+        status: str = "ORDERED",
+        expiry: str = "20220113",
+        timestamp: str = "2019-03-19T02:15:06.059Z",
+    ) -> dict:
+        data = {
+            "rootOrderId": root_order_id,
+            "orderId": order_id,
+            "symbol": symbol,
+            "side": side,
+            "orderType": order_type,
+            "executionType": execution_type,
+            "settleType": settle_type,
+            "size": str(size),
+            "price": str(price),
+            "status": status,
+            "expiry": expiry,
+            "timestamp": timestamp,
+        }
+
+        if client_order_id is not None:
+            data["clientOrderId"] = client_order_id
+
+        return data
+
+    @patch("gmo_fx.api.api_base.post")
+    def test_404_error(self, post_mock: MagicMock):
+        self.check_404_error(
+            post_mock,
+            lambda: self.call_api(order_id=123456789),
+        )
+
+    @patch("gmo_fx.api.api_base.post")
+    def test_check_url(self, post_mock: MagicMock) -> None:
+        post_mock.return_value = self.create_response()
+        self.call_api(order_id=123456789)
+        url: str = post_mock.mock_calls[0].args[0]
+        assert url.startswith("https://forex-api.coin.z.com/private/v1/changeOrder")
+
+    def check_parse_a_data(self, post_mock: MagicMock, **kwargs) -> Order:
+        post_mock.return_value = self.create_response(
+            data=[self.create_order_data(**kwargs)]
+        )
+        response = self.call_api(order_id=123456789)
+        assert len(response.orders) == 1
+        return response.orders[0]
+
+    @patch("gmo_fx.api.api_base.post")
+    def test_should_parse_order(self, post_mock: MagicMock):
+        order = self.check_parse_a_data(
+            post_mock,
+            root_order_id=2536464541,
+            client_order_id="abbb324dff",
+            order_id=156789,
+            symbol="EUR_USD",
+            side="SELL",
+            order_type="NORMAL",
+            execution_type="STOP",
+            settle_type="CLOSE",
+            size=6100,
+            price=155.44,
+            status="MODIFYING",
+            expiry="20190418",
+            timestamp="2024-09-13T15:21:03.059Z",
+        )
+
+        assert order.root_order_id == 2536464541
+        assert order.client_order_id == "abbb324dff"
+        assert order.order_id == 156789
+        assert order.symbol == Order.Symbol.EUR_USD
+        assert order.side == Order.Side.SELL
+        assert order.order_type == Order.OrderType.NORMAL
+        assert order.execution_type == Order.ExecutionType.STOP
+        assert order.settle_type == Order.SettleType.CLOSE
+        assert order.size == 6100
+        assert order.price == 155.44
+        assert order.status == Order.Status.MODIFYING
+        assert order.expiry == datetime(2019, 4, 18).date()
+        assert order.timestamp == datetime(
+            2024, 9, 13, 15, 21, 3, 59000, tzinfo=timezone.utc
+        )
+
+    @patch("gmo_fx.api.api_base.post")
+    def test_should_get_none_without_client_order_id(self, post_mock: MagicMock):
+        order = self.check_parse_a_data(post_mock, client_order_id=None)
+        assert order.client_order_id is None
+
+    @patch("gmo_fx.api.api_base.post")
+    def test_should_parse_some_data(self, post_mock: MagicMock):
+        post_mock.return_value = self.create_response(
+            data=[self.create_order_data(), self.create_order_data()]
+        )
+        response = self.call_api(order_id=123456789)
+        assert len(response.orders) == 2
+
+    def check_call_with(self, post_mock: MagicMock, **kwargs):
+        post_mock.return_value = self.create_response()
+        if "order_id" not in kwargs and "client_order_id" not in kwargs:
+            kwargs["order_id"] = 123456789
+        self.call_api(**kwargs)
+        request_body = post_mock.call_args.kwargs["data"]
+        return json.loads(request_body)
+
+    @patch("gmo_fx.api.api_base.post")
+    def test_should_call_api_with_order_id(self, post_mock: MagicMock) -> None:
+        body = self.check_call_with(post_mock, order_id=987654321)
+        assert body["orderId"] == 987654321
+
+    @patch("gmo_fx.api.api_base.post")
+    def test_should_call_api_without_order_id(self, post_mock: MagicMock) -> None:
+        body = self.check_call_with(
+            post_mock,
+            order_id=None,
+            client_order_id="test123",
+        )
+        assert "orderId" not in body.keys()
+
+    @patch("gmo_fx.api.api_base.post")
+    def test_should_call_api_with_client_order_id(
+        self,
+        post_mock: MagicMock,
+    ) -> None:
+        body = self.check_call_with(post_mock, client_order_id="alfsdj32432enl")
+        assert body["clientOrderId"] == "alfsdj32432enl"
+
+    @patch("gmo_fx.api.api_base.post")
+    def test_should_call_api_without_client_order_id(
+        self,
+        post_mock: MagicMock,
+    ) -> None:
+        body = self.check_call_with(
+            post_mock,
+            client_order_id=None,
+            order_id=123456789,
+        )
+        assert "clientOrderId" not in body.keys()
+
+    @patch("gmo_fx.api.api_base.post")
+    def test_should_call_api_with_price(self, post_mock: MagicMock) -> None:
+        body = self.check_call_with(post_mock, order_id=123456789, price=155.66)
+        assert body["price"] == "155.66"
+
+    @patch("gmo_fx.api.api_base.post")
+    def test_should_raise_error_without_order_identifier(
+        self,
+        post_mock: MagicMock,
+    ) -> None:
+        post_mock.return_value = self.create_response()
+        with pytest.raises(ValueError):
+            self.call_api(order_id=None, client_order_id=None)
+
+    @patch("gmo_fx.api.api_base.post")
+    def test_should_raise_error_without_price(self, post_mock: MagicMock) -> None:
+        post_mock.return_value = self.create_response()
+        with pytest.raises(ValueError):
+            self.call_api(price=None, order_id=123456789)
+
+    def test_should_import_from_package(self) -> None:
+        assert PackageChangeOrderApi is ChangeOrderApi

--- a/tests/test_change_order.py
+++ b/tests/test_change_order.py
@@ -109,7 +109,6 @@ class TestChangeOrderApi(ApiTestBase):
             order_id=156789,
             symbol="EUR_USD",
             side="SELL",
-            order_type="NORMAL",
             execution_type="STOP",
             settle_type="CLOSE",
             size=6100,
@@ -134,6 +133,11 @@ class TestChangeOrderApi(ApiTestBase):
         assert order.timestamp == datetime(
             2024, 9, 13, 15, 21, 3, 59000, tzinfo=timezone.utc
         )
+
+    @patch("gmo_fx.api.api_base.post")
+    def test_should_get_normal_order_type(self, post_mock: MagicMock):
+        order = self.check_parse_a_data(post_mock, order_type="NORMAL")
+        assert order.order_type == Order.OrderType.NORMAL
 
     @patch("gmo_fx.api.api_base.post")
     def test_should_get_none_without_client_order_id(self, post_mock: MagicMock):
@@ -203,12 +207,6 @@ class TestChangeOrderApi(ApiTestBase):
         post_mock.return_value = self.create_response()
         with pytest.raises(ValueError):
             self.call_api(order_id=None, client_order_id=None)
-
-    @patch("gmo_fx.api.api_base.post")
-    def test_should_raise_error_without_price(self, post_mock: MagicMock) -> None:
-        post_mock.return_value = self.create_response()
-        with pytest.raises(ValueError):
-            self.call_api(price=None, order_id=123456789)
 
     def test_should_import_from_package(self) -> None:
         assert PackageChangeOrderApi is ChangeOrderApi


### PR DESCRIPTION
## 概要

close #130

- `POST /private/v1/changeOrder` に対応する `ChangeOrderApi` を追加
- 注文変更レスポンスを型付き `Order` オブジェクトへ変換
- package import と URL、リクエストボディ、レスポンスパース、エラー時のテストを追加

## 確認

- `uv run pytest tests/test_change_order.py tests/test_change_oco_order.py`
- `uv run pytest`