### PR TITLE
#151 Add support for 7 new currency pair symbols

### DIFF
--- a/gmo_fx/common.py
+++ b/gmo_fx/common.py
@@ -18,6 +18,13 @@ class Symbol(Enum):
     GBP_USD = "GBP_USD"
     AUD_USD = "AUD_USD"
     NZD_USD = "NZD_USD"
+    HUF_JPY = "HUF_JPY"
+    SEK_JPY = "SEK_JPY"
+    EUR_GBP = "EUR_GBP"
+    AUD_NZD = "AUD_NZD"
+    AUD_CAD = "AUD_CAD"
+    NZD_CAD = "NZD_CAD"
+    NOK_SEK = "NOK_SEK"
 
 
 class Side(Enum):

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -21,6 +21,13 @@ class TestSymbolsApi(ApiTestBase):
         "GBP_USD",
         "AUD_USD",
         "NZD_USD",
+        "HUF_JPY",
+        "SEK_JPY",
+        "EUR_GBP",
+        "AUD_NZD",
+        "AUD_CAD",
+        "NZD_CAD",
+        "NOK_SEK",
     ]
 
     SYMBOLS_TABLE = {
@@ -38,6 +45,13 @@ class TestSymbolsApi(ApiTestBase):
         Rule.Symbol.GBP_USD: "GBP_USD",
         Rule.Symbol.AUD_USD: "AUD_USD",
         Rule.Symbol.NZD_USD: "NZD_USD",
+        Rule.Symbol.HUF_JPY: "HUF_JPY",
+        Rule.Symbol.SEK_JPY: "SEK_JPY",
+        Rule.Symbol.EUR_GBP: "EUR_GBP",
+        Rule.Symbol.AUD_NZD: "AUD_NZD",
+        Rule.Symbol.AUD_CAD: "AUD_CAD",
+        Rule.Symbol.NZD_CAD: "NZD_CAD",
+        Rule.Symbol.NOK_SEK: "NOK_SEK",
     }
 
     def call_api(

--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -22,6 +22,13 @@ class TestTickerApi(ApiTestBase):
         "GBP_USD",
         "AUD_USD",
         "NZD_USD",
+        "HUF_JPY",
+        "SEK_JPY",
+        "EUR_GBP",
+        "AUD_NZD",
+        "AUD_CAD",
+        "NZD_CAD",
+        "NOK_SEK",
     ]
 
     SYMBOLS_TABLE = {
@@ -39,6 +46,13 @@ class TestTickerApi(ApiTestBase):
         Ticker.Symbol.GBP_USD: "GBP_USD",
         Ticker.Symbol.AUD_USD: "AUD_USD",
         Ticker.Symbol.NZD_USD: "NZD_USD",
+        Ticker.Symbol.HUF_JPY: "HUF_JPY",
+        Ticker.Symbol.SEK_JPY: "SEK_JPY",
+        Ticker.Symbol.EUR_GBP: "EUR_GBP",
+        Ticker.Symbol.AUD_NZD: "AUD_NZD",
+        Ticker.Symbol.AUD_CAD: "AUD_CAD",
+        Ticker.Symbol.NZD_CAD: "NZD_CAD",
+        Ticker.Symbol.NOK_SEK: "NOK_SEK",
     }
 
     def create_ticker_data(


### PR DESCRIPTION
## Summary
This PR adds support for 7 new currency pair symbols to the GMO FX API client library.

## Key Changes
- Added 7 new currency pair symbols to the `Symbol` enum in `gmo_fx/common.py`:
  - HUF_JPY (Hungarian Forint / Japanese Yen)
  - SEK_JPY (Swedish Krona / Japanese Yen)
  - EUR_GBP (Euro / British Pound)
  - AUD_NZD (Australian Dollar / New Zealand Dollar)
  - AUD_CAD (Australian Dollar / Canadian Dollar)
  - NZD_CAD (New Zealand Dollar / Canadian Dollar)
  - NOK_SEK (Norwegian Krone / Swedish Krona)

- Updated test fixtures in `tests/test_symbols.py` to include the new symbols in both the `SYMBOLS_LIST` and `SYMBOLS_TABLE` test data

- Updated test fixtures in `tests/test_ticker.py` to include the new symbols in both the `SYMBOLS_LIST` and `SYMBOLS_TABLE` test data

## Implementation Details
The changes maintain consistency across the codebase by updating the symbol definitions and corresponding test mappings in parallel. All new symbols follow the existing naming convention of "CURRENCY_PAIR" format.

close #151

https://claude.ai/code/session_01MXSA7rKFgU8tT79S6crdnq